### PR TITLE
Update _nav.scss

### DIFF
--- a/src/_sass/partials/_nav.scss
+++ b/src/_sass/partials/_nav.scss
@@ -38,9 +38,7 @@
         z-index: 100;
     }
     ul {
-        list-style: none;
         counter-reset: nested-counter;
-        padding-left: 0;
         li {
             counter-increment: nested-counter;
             font-size: 98%;


### PR DESCRIPTION
Enable the bubbles in the unordered lists. There is no reason why the lists should be on purpose made less readable.

Before:
![image](https://user-images.githubusercontent.com/2521942/147173228-c82864e0-1c64-41ad-96ac-557c9a1aa35d.png)
After:
![image](https://user-images.githubusercontent.com/2521942/147173252-feb0d1f3-cda0-429e-a62d-3b2cc63434e7.png)

Before:
![image](https://user-images.githubusercontent.com/2521942/147173100-2e8c62ea-4a68-4752-b56c-93913c8795b5.png)
After:
![image](https://user-images.githubusercontent.com/2521942/147173123-b996fd25-6568-4ce1-96bc-eebd7d990450.png)

Before:
![image](https://user-images.githubusercontent.com/2521942/147173150-d775809f-dca7-4277-ad04-cdcfa1ab1251.png)
After:
![image](https://user-images.githubusercontent.com/2521942/147173167-66b1a78c-499e-4a79-b3cc-290133ce2dce.png)
